### PR TITLE
Encode primitive vs constructed form

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -836,7 +836,13 @@ fn encode_tag(c: ASN1Class, t: &BigUint) -> Vec<u8> {
     let cbyte = encode_class(c);
 
     match t.to_u8() {
-        Some(x) if x < 31 => {
+        Some(mut x) if x < 31 => {
+            if x == 0x10 || x == 0x11 {
+                // SEQUENCE and SET mut have the constructed encoding form (bit 5) set
+                // See: https://docs.microsoft.com/en-us/windows/desktop/seccertenroll/about-encoded-tag-bytes
+                x |= 0b00_10_00_00;
+            }
+
             vec![cbyte | x]
         }
         _ => {


### PR DESCRIPTION
`SEQUENCE` should always be encoded as `0x30` which is `0b10_0000 | 0x10` which means type `16` in "constructed" form. Bit5 unset means "primitive" form and is illegal for `SEQUENCE` but Go is strict and without this patch I couldn't get keys generated and encoded in Rust that Go would accept.

Example public key I generated without this patch:

```
102a100506032b6570032100b87ffc42162808917fa511a266446f5ab53c2737f45f3f79c0fc48314d902be3
```

Example now with this patch:

```
302a300506032b6570032100b87ffc42162808917fa511a266446f5ab53c2737f45f3f79c0fc48314d902be3
```

https://github.com/hashgraph/hedera-sdk-rust/blob/master/examples/generate_keys.rs#L8

---

https://lapo.it/asn1js/ fails to parse `SEQUENCE` as `0x10` as well.

