### PR TITLE
Reduce num dependencies, improve class implementation and add explicit tags

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,8 +9,9 @@ license-file = "LICENSE"
 repository = "https://github.com/acw/simple_asn1"
 
 [dependencies]
-chrono = "^0.4.0"
-num    = "^0.2.0"
+chrono     = "^0.4.0"
+num-bigint = "^0.2.0"
+num-traits = "^0.2.0"
 
 [dev-dependencies]
 quickcheck = "^0.7.1"


### PR DESCRIPTION
Hi,
I used [yasna](https://github.com/qnighy/yasna.rs) to parse ASN.1 before, but as it is not maintained anymore since a while I switched to this library. It works great for almost everything I want to do, just one thing is missing to encode OpenSSL EC keys.
OpenSSL uses for some reason an explicitely tagged value, which is in general used to distinguish multiple optional values with the same type. In the encoding it is a block where the `constructed` flag is set and the type is not `Universal` which wraps another block.

I did some reading on ASN.1 and DER (mostly [this](ftp://ftp.rsasecurity.com/pub/pkcs/ascii/layman.asc)) and came up with the following:

The default datatypes always have Universal as their class. If we
encounter another class while parsing, it is a tagged block.

I am not sure how (and if at all) we can distinguish explicitly and
implicitly tagged data. For now they should be parsed as unknown (or
explicit if they are a valid ASN.1 block).

PS: As a small change I copied [a small pull request](https://github.com/qnighy/yasna.rs/pull/7) from yasna, that reduces the dependencies quite a bit by only importing the needed num crates.