### PR TITLE
Make BigInt and BigUint public use

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,7 +36,7 @@ extern crate quickcheck;
 extern crate rand;
 
 use chrono::{DateTime,TimeZone,Utc};
-use num_bigint::{BigInt,BigUint};
+pub use num_bigint::{BigInt,BigUint};
 use num_traits::{FromPrimitive,One,ToPrimitive,Zero};
 use std::error::Error;
 use std::fmt;


### PR DESCRIPTION
To avoid having version problems with the dependency num-bigint, I think it would be better to export BigInt and BigUint from library to have the same version in the library and in the developer code.

So, in the code we can simply import without any version trouble with :
`use simple_asn1::BigUint;`
