### PR TITLE
Return error instead of panics on invalid ASN.1

### DIFF
--- a/fuzz/.gitignore
+++ b/fuzz/.gitignore
@@ -1,0 +1,3 @@
+target
+corpus
+artifacts

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,0 +1,22 @@
+
+[package]
+name = "simple_asn1-fuzz"
+version = "0.0.1"
+authors = ["Automatically generated"]
+publish = false
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies.simple_asn1]
+path = ".."
+[dependencies.libfuzzer-sys]
+git = "https://github.com/rust-fuzz/libfuzzer-sys.git"
+
+# Prevent this from interfering with workspaces
+[workspace]
+members = ["."]
+
+[[bin]]
+name = "fuzz_target_1"
+path = "fuzz_targets/fuzz_target_1.rs"

--- a/fuzz/fuzz_targets/fuzz_target_1.rs
+++ b/fuzz/fuzz_targets/fuzz_target_1.rs
@@ -1,0 +1,7 @@
+#![no_main]
+#[macro_use] extern crate libfuzzer_sys;
+extern crate simple_asn1;
+
+fuzz_target!(|data: &[u8]| {
+    let _ = simple_asn1::from_der(data);
+});

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -821,8 +821,8 @@ pub fn to_der(i: &ASN1Block) -> Result<Vec<u8>,ASN1EncodeErr> {
         }
         &ASN1Block::GeneralizedTime(_, ref time) => {
             let base = time.format("%Y%m%d%H%M%S.%f").to_string();
-            let zclear = base.trim_right_matches('0');
-            let dclear = zclear.trim_right_matches('.');
+            let zclear = base.trim_end_matches('0');
+            let dclear = zclear.trim_end_matches('.');
             let mut body = format!("{}Z", dclear).into_bytes();
 
             let inttag = BigUint::from_u8(0x18).unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -374,6 +374,9 @@ fn from_der_(i: &[u8], start_offset: usize)
         let soff = start_offset + index;
         let (tag, constructed, class) = decode_tag(i, &mut index);
         let len = decode_length(i, &mut index)?;
+        if i.len() < index + len {
+            return Err(ASN1DecodeErr::LengthTooLarge(index + len));
+        }
         let body = &i[index .. (index + len)];
 
         if class != ASN1Class::Universal {


### PR DESCRIPTION
Hi,
I use this library to find out if something is ASN.1 or not, unfortunately it often panics on invalid input.
To find all panics I added a [cargo-fuzz](https://fuzz.rs/book/) project and fixed all the panics it found.
With the final version, the fuzzer did not find any panic for half an hour.

Unfortunately this pr currently includes a breaking change because it adds error variants. So I’m not sure if you want to implement this someway else, e.g. return some of the existing errors instead.

Edit: I found [this commit](https://github.com/mxork/simple_asn1/commit/4f16e859502ccb1e1ddf90f7e9e311d18fcf1573) which also adds a `+ Error` bound to the error types.