### PR TITLE
use a machine-readable license key

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Adam Wick <awick@uhsure.com>"]
 description = "A simple DER/ASN.1 encoding/decoding library."
 categories = ["encoding"]
 keywords = ["ASN1","encoding","DER"]
-license-file = "LICENSE"
+license = "ISC"
 repository = "https://github.com/acw/simple_asn1"
 
 [dependencies]


### PR DESCRIPTION
See https://doc.rust-lang.org/cargo/reference/manifest.html#the-license-and-license-file-fields :

> If a package is using a nonstandard license, then the license-file field may be specified in lieu of the license
> field.

`simple_asn1` however uses a standard license (ISC, as per LICENSE).
Note that this is also a somewhat commonly used way by many projects
(see for example Cargo or serde).

Using the machine-readable SPX specifier instead of a text file helps
automatic tooling like [cargo-lichking](https://github.com/Nemo157/cargo-lichking) to check licenses of projects and
dependencies.