### PR TITLE
Use thiserror macro to derive Error + Display traits

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ edition = "2018"
 chrono     = { default-features = false, features = ["alloc"], version = "0.4" }
 num-bigint = { default-features = false, version = "0.3" }
 num-traits = { default-features = false, version = "0.2" }
+thiserror  = { default-features = false, version = "1" }
 
 [dev-dependencies]
 quickcheck = "0.9"


### PR DESCRIPTION
Following up on https://github.com/acw/simple_asn1/issues/17...

This removes the manual implementation of Display + Error for
ASN1EncodeErr and uses the derive macro from [thiserror](https://github.com/dtolnay/thiserror) to add
std Error and Display implementations for ANS1EncodeErr and
ASN1DecodeErr.

The unit tests seem to run with the change and I can confirm it
also unblocks me bumping my dependency on simple_asn1
in https://github.com/rib/jsonwebtokens as the api is again
compatible with the 0.4 api.