### PR TITLE
impl Eq for OID

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -195,7 +195,7 @@ impl PartialEq for ASN1Block {
 }
 
 /// An ASN.1 OID.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct OID(Vec<BigUint>);
 
 impl OID {


### PR DESCRIPTION
Closes #23

Tests pass (using `rustc` 1.45.2 on Linux) and clippy doesn't indicate any problems [there are some clippy warnings but nothing that looks related]