### PR TITLE
Add $crate:: metavariable to the oid! macro

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -286,9 +286,9 @@ macro_rules! oid {
         let mut res = Vec::new();
 
         $(
-            res.push(BigUint::from($e as u64));
+            res.push($crate::BigUint::from($e as u64));
         )*
-        OID::new(res)
+        $crate::OID::new(res)
     }};
 }
 


### PR DESCRIPTION
This allows using the oid macro without having to import BigUint

A little more context on this: I'm using RustCrypto/RSA which uses a fork of num-bigint and so within my code I already have a `BigUint` imported, but it is a different type than `simple_asn1`s `BigUint`. Currently to use the `oid` macro I must have `BigUint` imported from `simple_asn1` and using that name.

But also just ergonomically, if someone is just creating an OID and not otherwise encoding integers there doesn't seem to be any need for them to know that there are bigints under the hood.

https://doc.rust-lang.org/reference/macros-by-example.html#hygiene
