### PR TITLE
Use `vec!` in `oid!` macro

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -282,12 +282,7 @@ impl<'a> PartialEq<OID> for &'a OID {
 #[macro_export]
 macro_rules! oid {
     ( $( $e: expr ),* ) => {{
-        let mut res = Vec::new();
-
-        $(
-            res.push($crate::BigUint::from($e as u64));
-        )*
-        $crate::OID::new(res)
+        $crate::OID::new(vec![$($crate::BigUint::from($e as u64)),*])
     }};
 }
 


### PR DESCRIPTION
Hi,
This pull request changes the `oid!` macro to use the `vec!` macro rather than manually creating a vector and then pushing elements onto it one-by-one. The `vec!` macro creates a vector that is already of the correct size avoiding unnecessary reallocations.