### PR TITLE
Set `time/quickcheck` feature only in dev

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,9 @@ edition = "2018"
 num-bigint = { default-features = false, version = "0.4" }
 num-traits = { default-features = false, version = "0.2" }
 thiserror  = { default-features = false, version = "1" }
-time       = { default-features = false, version = "0.3", features = ["formatting", "macros", "parsing", "quickcheck"] }
+time       = { default-features = false, version = "0.3", features = ["formatting", "macros", "parsing"] }
 
 [dev-dependencies]
 quickcheck = "1.0.3"
 rand = "0.8.4"
+time = { default-features = false, version = "0.3", features = ["formatting", "macros", "parsing", "quickcheck"] }


### PR DESCRIPTION
I noticed when working on a crate that `quickcheck` was showing up in the `Cargo.lock`, which I thought was odd since I wasn't using it and it seems like something that ought to be under a feature. Turns out it was coming from `time`, which does put it behind a feature, but `simple_asn1` always turns it on!

This PR simply duplicates the `time` dependency in `dev-dependencies`, and removes the `quickcheck` feature from the non-dev entry.

Since nothing is re-exported from `time` this ought to be a non-breaking change. I'm not familiar enough with how feature resolution works to say for certain that it couldn't break builds – perhaps if a user of both `simple_asn1` and `time` was depending on `Time::arbitrary` without explicitly enabling it themselves...?