### PR TITLE
Update rust edition to 2021

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ categories = ["encoding"]
 keywords = ["ASN1","encoding","DER"]
 license = "ISC"
 repository = "https://github.com/acw/simple_asn1"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 num-bigint = { default-features = false, version = "0.4" }


### PR DESCRIPTION
Using older Cargo resolver introduces an issue with `time` dependency features. The `quickcheck` feature of `time` create, specified in the `dev-dependencies` block gets used even for non-dev dependencies and in all crates that use simple_asn1. Updating the edition fixes the issue.

Another option is to specify the resolver type 2 in Cargo.tom, but I cannot think of any downsides of using more recent language version.

Please, refer to this issue for reference: https://github.com/rust-lang/cargo/issues/10719