### PR TITLE
Update Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,4 @@
-[package]
+e[package]
 name = "simple_asn1"
 version = "0.6.3"
 authors = ["Adam Wick <awick@uhsure.com>"]
@@ -13,7 +13,7 @@ edition = "2018"
 num-bigint = { default-features = false, version = "0.4" }
 num-traits = { default-features = false, version = "0.2" }
 thiserror  = { default-features = false, version = "2" }
-time       = { default-features = false, version = "0.3", features = ["formatting", "macros", "parsing"] }
+time       = { default-features = false, version = "0.3.47", features = ["formatting", "macros", "parsing"] }
 
 [dev-dependencies]
 quickcheck = "1.0.3"


### PR DESCRIPTION
Bumps the dependency to at least 0.3.47 as per the advisory

[Advisory](https://rustsec.org/advisories/RUSTSEC-2026-0009.html)

(even though this crate may not be using the function mentioned in the advisory, it is better to bump it to ensure that there is no chance of other dependencies pulling it)