### PR TITLE
Dependencies upgraded to the latest ones

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,12 +10,11 @@ repository = "https://github.com/acw/simple_asn1"
 edition = "2018"
 
 [dependencies]
-num-bigint = { default-features = false, version = "0.4" }
+num-bigint = { default-features = false, version = "0.5" }
 num-traits = { default-features = false, version = "0.2" }
 thiserror  = { default-features = false, version = "2" }
-time       = { default-features = false, version = "0.3.47", features = ["formatting", "macros", "parsing"] }
+time       = { default-features = false, version = "0.3.55", features = ["formatting", "macros", "parsing"] }
 
 [dev-dependencies]
-quickcheck = "1.0.3"
-rand = "0.8.4"
-time = { default-features = false, version = "0.3", features = ["formatting", "macros", "parsing", "quickcheck"] }
+quickcheck = "1.1.0"
+time = { default-features = false, version = "0.3.55", features = ["formatting", "macros", "parsing", "quickcheck"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -515,7 +515,7 @@ fn from_der_(i: &[u8], start_offset: usize) -> Result<Vec<ASN1Block>, ASN1Decode
 
                 let v = format!("{}{}", y_prefix, v);
 
-                let format = time::format_description::parse(
+                let format = time::format_description::parse_borrowed::<1>(
                     "[year][month][day][hour repr:24][minute][second]Z",
                 )
                 .unwrap();
@@ -548,7 +548,7 @@ fn from_der_(i: &[u8], start_offset: usize) -> Result<Vec<ASN1Block>, ASN1Decode
                     v.insert(idx, '0');
                 }
 
-                let format = time::format_description::parse(
+                let format = time::format_description::parse_borrowed::<1>(
                     "[year][month][day][hour repr:24][minute][second].[subsecond]Z",
                 )
                 .unwrap();
@@ -827,7 +827,7 @@ pub fn to_der(i: &ASN1Block) -> Result<Vec<u8>, ASN1EncodeErr> {
             Ok(res)
         }
         ASN1Block::UTCTime(_, ref time) => {
-            let format = time::format_description::parse(
+            let format = time::format_description::parse_borrowed::<1>(
                 "[year][month][day][hour repr:24][minute][second]Z",
             )
             .unwrap();
@@ -844,7 +844,7 @@ pub fn to_der(i: &ASN1Block) -> Result<Vec<u8>, ASN1EncodeErr> {
             Ok(res)
         }
         ASN1Block::GeneralizedTime(_, ref time) => {
-            let format = time::format_description::parse(
+            let format = time::format_description::parse_borrowed::<1>(
                 "[year][month][day][hour repr:24][minute][second].[subsecond]",
             )
             .unwrap();


### PR DESCRIPTION
This is potentially semver-breaking because num_bigint types are exposed through simple_asn1's public API, so this should probably be released as 0.7.0.